### PR TITLE
Removed open ai api key environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,6 @@ SENTRY_DSN=
 
 DOCKER_IMAGE_BACKEND=kaapi-guardrails-backend
 
-# require as a env if you want to use doc transformation
-OPENAI_API_KEY="<ADD-KEY>"
 GUARDRAILS_HUB_API_KEY="<ADD-KEY>"
 # SHA-256 hex digest of your bearer token (64 lowercase hex chars)
 AUTH_TOKEN="<ADD-HASH-TOKEN>"

--- a/.env.test.example
+++ b/.env.test.example
@@ -21,8 +21,6 @@ SENTRY_DSN=
 
 DOCKER_IMAGE_BACKEND=kaapi-guardrails-backend
 
-# require as a env if you want to use doc transformation
-OPENAI_API_KEY="<ADD-KEY>"
 GUARDRAILS_HUB_API_KEY="<ADD-KEY>"
 # SHA-256 hex digest of your bearer token (64 lowercase hex chars)
 AUTH_TOKEN="<ADD-HASH-TOKEN>"


### PR DESCRIPTION
## Summary

Target issue is #65.
Removed the Open AI API Key environment variable since it's not being used anywhere so far. It will be taken up in the future list of validators, so, we will add it then itself.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes
  * Removed OPENAI_API_KEY configuration requirement from environment setup examples.
