### PR TITLE
Hotfix: drop name field in run guardrail endpoint

### DIFF
--- a/backend/app/schemas/guardrail_config.py
+++ b/backend/app/schemas/guardrail_config.py
@@ -79,6 +79,7 @@ class GuardrailRequest(SQLModel):
             "is_enabled",
             "created_at",
             "updated_at",
+            "name",
         }
 
         for validator in validators:

--- a/backend/app/schemas/guardrail_config.py
+++ b/backend/app/schemas/guardrail_config.py
@@ -73,13 +73,13 @@ class GuardrailRequest(SQLModel):
 
         drop_fields = {
             "id",
+            "name",
             "organization_id",
             "project_id",
             "stage",
             "is_enabled",
             "created_at",
             "updated_at",
-            "name",
         }
 
         for validator in validators:


### PR DESCRIPTION
Target Issue is #87 

## Notes

* **Bug Fixes**
  * Improved validator configuration processing to ensure consistent payload normalization when validators are submitted through the API.
  * In simpler words now that we have included name as well in the config of validator config, then name will be in the response body of the get validator config endpoint as well. Now in [kaapi backend's code](https://github.com/ProjectTech4DevAI/kaapi-backend/blob/main/backend/app/services/llm/guardrails.py), according to the given validator config id, we fetch the validator config and pass it to run guardrails endpoint, we have to specify the fields this endpoint should ignore so that we have to only process values needed to run the validator, that is why making this change was needed