### PR TITLE
Fixed LLM critic bug

### DIFF
--- a/backend/app/api/routes/guardrails.py
+++ b/backend/app/api/routes/guardrails.py
@@ -224,7 +224,9 @@ def _validate_with_guard(
                                 log_result.error_message
                             )
                         else:
-                            error_message = _redact_input(log_result.error_message, data)
+                            error_message = _redact_input(
+                                log_result.error_message, data
+                            )
                         break
 
         return _finalize(

--- a/backend/app/api/routes/guardrails.py
+++ b/backend/app/api/routes/guardrails.py
@@ -219,7 +219,12 @@ def _validate_with_guard(
                 for log in logs:
                     log_result = log.validation_result
                     if isinstance(log_result, FailResult) and log_result.error_message:
-                        error_message = log_result.error_message
+                        if log.validator_name == "guardrails/llm_critic":
+                            error_message = _normalize_llm_critic_error(
+                                log_result.error_message
+                            )
+                        else:
+                            error_message = log_result.error_message
                         break
 
         return _finalize(
@@ -284,3 +289,15 @@ def add_validator_logs(
         )
 
         validator_log_crud.create(log=validator_log)
+
+
+def _normalize_llm_critic_error(message: str) -> str:
+    if "failed the following metrics" in message:
+        return "The response did not meet the required quality criteria."
+    if "missing or has invalid evaluations" in message:
+        return (
+            "The LLM critic could not evaluate one or more metrics. "
+            "The critic model returned an incomplete or malformed response. "
+            "Please retry."
+        )
+    return message

--- a/backend/app/api/routes/guardrails.py
+++ b/backend/app/api/routes/guardrails.py
@@ -8,6 +8,7 @@ from sqlmodel import Session
 
 from app.api.deps import AuthDep, SessionDep
 from app.core.constants import BAN_LIST, REPHRASE_ON_FAIL_PREFIX
+from app.core.enum import ValidatorType
 from app.core.guardrail_controller import build_guard, get_validator_config_models
 from app.core.exception_handlers import _safe_error_message
 from app.core.validators.config.ban_list_safety_validator_config import (
@@ -206,29 +207,7 @@ def _validate_with_guard(
             )
 
         # Case 2: validation failed without a fix
-        error_message = "Validation failed"
-
-        history = getattr(guard, "history", None)
-        if history and getattr(history, "last", None):
-            iterations = getattr(history.last, "iterations", None)
-            if iterations:
-                iteration = iterations[-1]
-                logs = getattr(
-                    getattr(iteration, "outputs", None), "validator_logs", []
-                )
-                for log in logs:
-                    log_result = log.validation_result
-                    if isinstance(log_result, FailResult) and log_result.error_message:
-                        if log.validator_name == "guardrails/llm_critic":
-                            error_message = _normalize_llm_critic_error(
-                                log_result.error_message
-                            )
-                        else:
-                            error_message = _redact_input(
-                                log_result.error_message, data
-                            )
-                        break
-
+        error_message = _extract_error_from_guard(guard, data) or "Validation failed"
         return _finalize(
             status=RequestStatus.ERROR,
             error_message=error_message,
@@ -236,11 +215,39 @@ def _validate_with_guard(
 
     except Exception as exc:
         # Case 3: unexpected system / runtime failure
+        # First try to extract structured fail results from guard history.
+        # This handles on_fail="exception" where guardrails raises instead of returning.
+        if guard is not None:
+            extracted = _extract_error_from_guard(guard, data)
+            if extracted is not None:
+                return _finalize(status=RequestStatus.ERROR, error_message=extracted)
+
         safe_msg = _redact_input(_safe_error_message(exc), data)
         return _finalize(
             status=RequestStatus.ERROR,
             error_message=safe_msg,
         )
+
+
+def _extract_error_from_guard(guard: Guard, data: str) -> str | None:
+    """
+    Scans the guard's last history iteration for the first FailResult and returns
+    a normalized, redacted error message. Returns None if no fail result is found.
+    """
+    history = getattr(guard, "history", None)
+    if not history or not getattr(history, "last", None):
+        return None
+    iterations = getattr(history.last, "iterations", None)
+    if not iterations:
+        return None
+    logs = getattr(getattr(iterations[-1], "outputs", None), "validator_logs", [])
+    for log in logs:
+        log_result = log.validation_result
+        if isinstance(log_result, FailResult) and log_result.error_message:
+            if log.validator_name == ValidatorType.LLMCritic.name:
+                return _normalize_llm_critic_error(log_result.error_message)
+            return _redact_input(log_result.error_message, data)
+    return None
 
 
 def _redact_input(error_message: str, input_text: str) -> str:

--- a/backend/app/tests/test_llm_validators.py
+++ b/backend/app/tests/test_llm_validators.py
@@ -9,6 +9,7 @@ from app.core.validators.config.topic_relevance_safety_validator_config import (
 from app.core.validators.config.llm_critic_safety_validator_config import (
     LLMCriticSafetyValidatorConfig,
 )
+from app.api.routes.guardrails import _normalize_llm_critic_error
 
 _SAMPLE_TOPIC_CONFIG = dict(
     type="topic_relevance",
@@ -97,3 +98,21 @@ def test_llm_critic_build_proceeds_when_openai_key_present():
         config.build()
 
     mock_llm_critic.assert_called_once()
+
+
+def test__normalize_llm_critic_error_maps_failed_metrics():
+    raw = "The response failed the following metrics: ['quality']."
+    result = _normalize_llm_critic_error(raw)
+    assert result == "The response did not meet the required quality criteria."
+
+
+def test__normalize_llm_critic_error_maps_missing_invalid_metrics():
+    raw = "The response is missing or has invalid evaluations for the following metrics: ['quality']."
+    result = _normalize_llm_critic_error(raw)
+    assert "could not evaluate" in result
+    assert "Please retry" in result
+
+
+def test__normalize_llm_critic_error_passes_through_unknown_messages():
+    raw = "Some other validator error."
+    assert _normalize_llm_critic_error(raw) == raw


### PR DESCRIPTION
## Summary

Target issue is #76 
Explain the **motivation** for making this change. What existing problem does the pull request solve?
When the LLM critic validator failed, two different error strings surface directly in the API response:

"The response failed the following metrics: ['query']." — returned when the LLM scored a metric below the configured threshold (normal failure path)
"The response is missing or has invalid evaluations for the following metrics: ['query']." — returned when the LLM's response was malformed, missing a metric key, or returned an out-of-range score (including 0, which LLMCritic treats as invalid rather than a failing score)
These messages are internal implementation details of the third-party library and are not meaningful to end users.

Solution
Added _normalize_llm_critic_error to guardrails.py which intercepts these two known strings and replaces them with clear user-facing messages. The function is only invoked when the failing validator is guardrails/llm_critic (checked via log.validator_name), so no other validators are affected. All other error messages pass through unchanged.

Changes - 
1. `backend/app/api/routes/guardrails.py` — gate error extraction on log.validator_name for LLM critic logs; add _normalize_llm_critic_error helper at the bottom of the file.
2. `backend/app/tests/test_llm_validators.py `— 3 new tests covering both error mappings and the pass-through case for unrelated validators

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation failure messages are now standardized and clearer: structured errors are extracted when available, LLM-critic style messages are normalized to concise, user-friendly wording, and unknown cases fall back to a safe redacted message.

* **Tests**
  * Added unit tests verifying normalization for LLM-critic and evaluation-missing messages, plus a fallback for unrecognized validator errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->