### PR TITLE
enhancement: adding coderabbit yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+reviews:
+  auto_review:
+    enabled: true
+    labels:
+      - "ready-for-review"
+    base_branches:
+      - ".*"  # allows all branches


### PR DESCRIPTION
## Summary

Target issue is #111 

### Notes

Added a configuration file for coderabbit which configures it in a way that coderabbit should only initiate the review after the PR owner selects "ready for review" as the label, and coderabbit should not get triggered with every commit if it is not ready for review yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated code reviews on all branches with a new "ready-for-review" label workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProjectTech4DevAI/kaapi-guardrails/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->