### PR TITLE
fix(release): update the deployment script

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -31,7 +31,7 @@ jobs:
           INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
           BUILD_DIRECTORY: ${{ secrets.BUILD_DIRECTORY }}
         run: |
-          DEPLOY_CMD="cd ${BUILD_DIRECTORY} && git fetch --tags origin && git checkout --force ${{ github.sha }} && docker compose build && docker compose run --rm --entrypoint '' backend uv run --frozen alembic upgrade head && docker compose up -d --remove-orphans && docker image prune -f"
+          DEPLOY_CMD="cd ${BUILD_DIRECTORY} && git fetch --tags origin && git checkout --force ${{ github.sha }} && docker compose build && docker compose run --rm --entrypoint '' backend uv run --frozen alembic upgrade head && docker compose up -d --remove-orphans && docker image prune -f && docker builder prune -af"
 
           CMD_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -82,7 +82,7 @@ jobs:
               exit 1
             fi
 
-            sleep 15
+            sleep 25
           done
 
           echo "Deployment timed out after waiting too long."

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -30,7 +30,7 @@ jobs:
           INSTANCE_ID: ${{ secrets.STAGING_EC2_INSTANCE_ID }}
           BUILD_DIRECTORY: ${{ secrets.BUILD_DIRECTORY }}
         run: |
-          DEPLOY_CMD='sudo -iu ec2-user bash -lc \"cd '"${BUILD_DIRECTORY}"' && git fetch origin && git reset --hard origin/main && docker compose build && docker compose run --rm --entrypoint \\\"\\\" backend uv run --frozen alembic upgrade head && docker compose up -d --remove-orphans && docker image prune -f\"'
+          DEPLOY_CMD='sudo -iu ec2-user bash -lc \"cd '"${BUILD_DIRECTORY}"' && git fetch origin && git reset --hard origin/main && docker compose build && docker compose run --rm --entrypoint \\\"\\\" backend uv run --frozen alembic upgrade head && docker compose up -d --remove-orphans && docker image prune -f && docker builder prune -af\"'
 
           CMD_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -81,7 +81,7 @@ jobs:
               exit 1
             fi
 
-            sleep 15
+            sleep 25
           done
 
           echo "Deployment timed out after waiting too long."

--- a/backend/notebooks/analysis-pii.py
+++ b/backend/notebooks/analysis-pii.py
@@ -11,10 +11,7 @@ def _():
     import io
     from app.core.validators.topic_relevance_llm import TopicRelevanceLLM
     from app.core.validators.pii_remover import PIIRemover
-    from guardrails.validators import (
-        FailResult,
-        PassResult
-    )
+    from guardrails.validators import FailResult, PassResult
     from sklearn.metrics import classification_report, confusion_matrix
 
     return PIIRemover, classification_report, confusion_matrix, io, mo, pd
@@ -22,11 +19,13 @@ def _():
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     # Expected Format of the data
     - query : The text message that you want to run against the validators
     - guardrail_triggered : name of the validators you expect to catch this query. In case of queries that should get caught by multiple validators, you can separate them with a "+" sign. for instance : PII + topic_relevance
-    """)
+    """
+    )
     return
 
 
@@ -50,9 +49,11 @@ def _(file_picker, io, mo, pd):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     # Calculate PII match
-    """)
+    """
+    )
     return
 
 
@@ -69,14 +70,17 @@ def _(PIIRemover):
             "IN_VOTER",
             "IN_PASSPORT",
             "IN_VEHICLE_REGISTRATION",
-            "URL"],
+            "URL",
+        ],
     )
     return (pii_validator,)
 
 
 @app.cell
 def _(pii_validator):
-    _result = pii_validator._validate("hey buddy budgeting kya hota haiii muje asan trike se smjao with examples")
+    _result = pii_validator._validate(
+        "hey buddy budgeting kya hota haiii muje asan trike se smjao with examples"
+    )
     _result.outcome == "fail"
     return
 
@@ -87,7 +91,7 @@ def _(user_df):
         return "PII" in input
 
     user_df["pii_true"] = user_df["guardrail_triggered"].apply(actual_label)
-    user_df[["query", "guardrail_triggered" ,"pii_true"]]
+    user_df[["query", "guardrail_triggered", "pii_true"]]
     return
 
 
@@ -98,15 +102,17 @@ def _(pii_validator, user_df):
         return result.outcome == "fail"
 
     user_df["pii_pred"] = user_df["query"].apply(is_pii)
-    user_df[["query","guardrail_triggered","pii_true","pii_pred"]]
+    user_df[["query", "guardrail_triggered", "pii_true", "pii_pred"]]
     return
 
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     # Scores
-    """)
+    """
+    )
     return
 
 
@@ -118,9 +124,11 @@ def _(classification_report, user_df):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     # Confusion Matrix
-    """)
+    """
+    )
     return
 
 
@@ -134,9 +142,11 @@ def _(confusion_matrix, user_df):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     ## False Negatives
-    """)
+    """
+    )
     return
 
 
@@ -148,9 +158,11 @@ def _(user_df):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     ## True Positives
-    """)
+    """
+    )
     return
 
 
@@ -162,9 +174,11 @@ def _(user_df):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     ## False Positives
-    """)
+    """
+    )
     return
 
 
@@ -176,9 +190,11 @@ def _(user_df):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    mo.md(
+        r"""
     ## True Negatives
-    """)
+    """
+    )
     return
 
 


### PR DESCRIPTION
## Summary
The EC2 hosts running staging and production were repeatedly filling up their EBS volumes. The culprit was BuildKit build cache: every deploy runs docker compose build, which writes a fresh set of cache layers, and nothing ever reclaimed them. The existing docker image prune -f only removes dangling images — it does not touch build cache, so the cache grew unbounded until deploys started failing on "no space left on device".

This PR appends `docker builder prune -af` to the end of the deploy command chain in both workflows:
1. [.github/workflows/cd-staging.yml](https://github.com/ProjectTech4DevAI/kaapi-guardrails/pull/138/changes#diff-218ff9f8760f091f1283f4c29d44643e3a18bc1245d4641034cb08da2d16630a)
2. [.github/workflows/cd-production.yml](https://github.com/ProjectTech4DevAI/kaapi-guardrails/pull/138/changes#diff-20978261103bced7e6fc10d596a16b6c206662b31d63842ca3fc8cc559344b98)

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.